### PR TITLE
Add conditional Join button

### DIFF
--- a/_layouts/working_groups.html
+++ b/_layouts/working_groups.html
@@ -37,7 +37,13 @@ layout: default
     <header>
         <div class="title">
             <h3>Members</h3>
-            <p>The {{page.title}} working group is composed of {{page.members | size}} members</p>
+            <p>The {{page.title}} working group is composed of {{page.members | size}} members.</p>
+            {% if page.join %}
+            <p>
+            <a href="{{ page.join }}" target="_blank" class="btn btn-primary">Join working group<i class="fas fa-user-plus"
+                    style="font-size: 0.8em"></i></a>
+            </p>
+            {% endif %}
         </div>
     </header>
 


### PR DESCRIPTION
Adds the "Join Working Group" button also at listing of group (which with content will be at bottom of page, far from the top-right corner button)

Perhaps colours of btn-primary (and other primary bootstrap) colours need adjustment in stylesheet globally, but this blue also works:

![image](https://user-images.githubusercontent.com/253413/151793442-85b1560f-38b6-4bb3-a9a7-190508fe19a6.png)
