### PR TITLE
No need for both task forces and working groups

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,8 +20,10 @@
                     Research
                 </a>
                 <div class="dropdown-menu" aria-labelledby="researchDropdown">
+                    <!--
                     <a class="dropdown-item" href="/task_forces">
                         <i class="fas fa-dot-circle color-3"></i> Task Forces</a>
+                    -->
                     <a class="dropdown-item" href="/groups">
                         <i class="fas fa-dot-circle color-4"></i> Working Groups</a>
                     <a class="dropdown-item" href="/frameworks">

--- a/_includes/menu.html
+++ b/_includes/menu.html
@@ -14,11 +14,13 @@
                     <h3>Workflow Registries</h3>
                 </a>
             </li>
+            <!--
             <li>
                 <a href="/task_forces">
                     <h3>Task Forces</h3>
                 </a>
             </li>
+            -->
             <li>
                 <a href="/groups">
                     <h3>Working Groups</h3>


### PR DESCRIPTION
`/task_force` was 404 - I guess meant to be similar to `/groups` listing?

Perhaps we can change title to "Working Groups" to "Working Groups and task forces" as the line is blurry  (for instance Workflow Run RO-Crate is more of a time-limited task force)
