### PR TITLE
Add explicit "Contact us" page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -50,7 +50,7 @@
     <nav class="main">
         <ul>
             <li>
-                <a href="mailto:contact@workflows.community" class="getinvolved">Get Involved!</a>
+                <a href="/contact" class="getinvolved">Get Involved!</a>
             </li>
             <li class="menu">
                 <a class="fa-bars" href="#menu">Menu</a>

--- a/_layouts/jobs.html
+++ b/_layouts/jobs.html
@@ -17,7 +17,7 @@ layout: default
         </div>
     </header>
 
-    <div class="job-content">
+    <main class="job-content">
         <div class="row">
             <div class="col-sm-12 col-md-8">
                 {{content | markdownify}}
@@ -37,6 +37,6 @@ layout: default
                 </div>
             </div>
         </div>
-    </div>
+    </main>
 
 </article>

--- a/_layouts/working_groups.html
+++ b/_layouts/working_groups.html
@@ -26,9 +26,9 @@ layout: default
         </div>
     </header>
 
-    <div class="wg-content">
+    <main class="wg-content">
         {{content | markdownify}}
-    </div>
+    </main>
     <br /><br />
 </article>
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -4671,25 +4671,25 @@ body.is-menu-visible #menu {
     text-decoration: none;
 }
 
-.wg-content p, .job-content p {
+main p {
     margin-bottom: 1em;
 }
 
-.wg-content h1, .job-content h1 {
+main h1 {
     font-size: 1.2em;
 }
 
-.wg-content h2, .job-content h2 {
+main h2 {
     font-size: 1.1em;
     letter-spacing: 0.15em;
 }
 
-.wg-content h3, .job-content h3 {
+main h3 {
     font-size: 1em;
     letter-spacing: 0.1em;
 }
 
-.wg-content a, .job-content a {
+main a {
     color:rgb(204, 110, 3)
 }
 

--- a/page_contact.html
+++ b/page_contact.html
@@ -31,14 +31,19 @@ permalink: /contact
         
         <section>
             <h2>Join us</h2>
+            <a href="https://forms.gle/ihiyRoZJMYeWXJid6" target="_blank" class="btn btn-primary" style="margin-top: -2em; margin-bottom: 0;">Join WCI&nbsp;&nbsp;<i class="fas fa-user-plus"
+                style="font-size: 0.8em"></i></a>               
             <p>Anyone who supports the Workflows Community Initiative's mission are free to
                 <a target="_blank" href="https://forms.gle/ihiyRoZJMYeWXJid6">join</a>
                 as a <a href="/members"> WCI member</a>.
             </p>
             <p>
+                You may also consider joining one of the <a href="/groups/">working groups and task forces</a>.
+            </p>
+            <p>
             An informal 
             <a target="_blank" href="https://join.slack.com/t/workflowscommunity/shared_invite/zt-10tn61tdy-p9sExEOBoCDpaPmj3G3Jtg">Slack chat</a> 
-            allows communication between WCI members and anyone interested in workflows. 
+            allows communication between WCI members and is available for anyone interested in workflows. 
             </p>
         </section>
     </main>

--- a/page_contact.html
+++ b/page_contact.html
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Get in touch
+permalink: /contact
+---
+
+<article class="post">
+    <header>
+        <div class="title">
+            <h2>Get in touch</h2>
+            <p>
+                There are multiple ways for you to get in touch and join the Workflows Community Initiative.
+            </p>
+        </div>
+    </header>
+    <main>
+        <section>
+            <h2>Contact us</h2>
+            <p>
+                You may contact the <a href="/about">WCI leadership team</a> through:            
+            </p>
+            <dl>
+                <dt>email</dt>
+                    <dd><a href="mailto:contact@workflows.community">contact@workflows.community</a></dd>
+                <dt>Twitter</dt>
+                    <dd><a href="http://twitter.com/WorkflowsCI">@WorkflowsCI</a></dd>
+                <dt>Slack</dt>
+                    <dd><a href="https://join.slack.com/t/workflowscommunity/shared_invite/zt-10tn61tdy-p9sExEOBoCDpaPmj3G3Jtg">workflowscommunity.slack.com</a></dd>
+            </dl>
+        </section>
+        
+        <section>
+            <h2>Join us</h2>
+            <p>Anyone who supports the Workflows Community Initiative's mission are free to
+                <a target="_blank" href="https://forms.gle/ihiyRoZJMYeWXJid6">join</a>
+                as a <a href="/members"> WCI member</a>.
+            </p>
+            <p>
+            An informal 
+            <a target="_blank" href="https://join.slack.com/t/workflowscommunity/shared_invite/zt-10tn61tdy-p9sExEOBoCDpaPmj3G3Jtg">Slack chat</a> 
+            allows communication between WCI members and anyone interested in workflows. 
+            </p>
+        </section>
+    </main>
+</article>


### PR DESCRIPTION
.. as the left-hand icons can be a bit cryptic (you have to hover over) - this re-iterates the same links but in text.

This also makes a more convenient target for the "Get Involved" tab on top-right than email.

Note that instead of adding yet another `.about-content` CSS class to get hyperlink colours etc. I changed these to use `<main>` to wrap the main article text.

![image](https://user-images.githubusercontent.com/253413/152196864-bf2fd050-a686-451c-9b09-3d1f725868ad.png)
