### PR TITLE
Add CWL4HPC to external working groups

### DIFF
--- a/_data/working_groups.yml
+++ b/_data/working_groups.yml
@@ -17,3 +17,8 @@
   description: DFG Collaborative Research Center 1404 at Humboldt-Universität zu Berlin, Germany
   link: https://fonda.hu-berlin.de/
   status: Active
+
+- name: CWL4HPC
+  description: This group aims to identify workflow patterns capable of modeling large-scale scientific applications and implement the related Common Workflow Language enhancement proposals.
+  link: https://www.commonwl.org/working-groups/cwl4hpc
+  status: Active


### PR DESCRIPTION
Thic commit adds the newly created `CWL4HPC` working group to be listed in the Workflow Community website.

For more information on the CWL4HPC working group visit https://www.commonwl.org/working-groups/cwl4hpc