### PR TITLE
Add Kerblam! to workflow list

### DIFF
--- a/_data/workflow_systems.yml
+++ b/_data/workflow_systems.yml
@@ -138,3 +138,8 @@
 # - organization: icui
 #   repository: nnodes
 #   type: github
+
+- organization: mrhedmad
+  repository: kerblam
+  type: github
+  metadata: .wci.yml


### PR DESCRIPTION
Hello! I wanted to propose Kerblam! to be added to the list of workflows in the community. Kerblam! is not a workflow runner *per se*, but it manages the execution of other runners (currently just `make` and generally anything ran in `bash`) for small-ish projects.
You can find more about it in the [repo](https://github.com/MrHedmad/kerblam) directly or on the documentation site https://kerblam.dev/.

I've added the [`.wci.yml`](https://github.com/MrHedmad/kerblam/blob/main/.wci.yml) file to the repository already. I hope it's well-formed.

I hope it's fine if it's not hosted under a community account, but just my personal one.

Thanks for taking this into consideration!